### PR TITLE
Better panel sizing

### DIFF
--- a/src/sysdig-dashboard-importer.js
+++ b/src/sysdig-dashboard-importer.js
@@ -273,7 +273,7 @@ function buildPanelGridLayout(sysdigDashboard, sysdigPanel) {
 
     // keep w/h ratio similar to Sysdig by reducing height by 50%
     return {
-        h: layout.size_y / SYSDIG_COLUMN_COUNT * GRAFANA_COLUMN_COUNT / 2,
+        h: Math.ceil(layout.size_y / SYSDIG_COLUMN_COUNT * GRAFANA_COLUMN_COUNT / 2 * 1.5),
         w: layout.size_x / SYSDIG_COLUMN_COUNT * GRAFANA_COLUMN_COUNT,
         x: (layout.col - 1) / SYSDIG_COLUMN_COUNT * GRAFANA_COLUMN_COUNT,
         y: (layout.row - 1) / SYSDIG_COLUMN_COUNT * GRAFANA_COLUMN_COUNT / 2


### PR DESCRIPTION
Use a 1.5x factor for panel height when importing dashboards from Sysdig. This way, the dashboard layout will look more similar to the original dashboard.

**Original**
<img width="1552" alt="screenshot 2018-05-05 11 43 47" src="https://user-images.githubusercontent.com/5033993/39666510-9c9e6ca6-5059-11e8-8373-d1e67d447b56.png">

**After**
<img width="1552" alt="screenshot 2018-05-05 11 41 59" src="https://user-images.githubusercontent.com/5033993/39666512-9fbad884-5059-11e8-8390-ac9a8dbf1322.png">

**Before**
<img width="1552" alt="screenshot 2018-05-05 11 33 08" src="https://user-images.githubusercontent.com/5033993/39666513-a3861fbe-5059-11e8-99ca-38eab6c5d619.png">
