### PR TITLE
Support variable options (filter, pagination)

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,9 @@ Some notes about variables for label values:
 
 * You can use a *Query*, *Custom*, or *Constant* variables.
 * *Query* variables can use the `label_values(label_name)` function, that returns a list of label values for the specified label name.
+* The query accepts the following optional parameters:
+  1. `filter` to limit the list of values according to the specified filter. Example: `label_values(kubernetes.namespace.name, filter='kubernetes.deployment.name = "foo"')` to return a list of Kubernetes namespaces within the Kubernetes deployment named `foo`. You can also refer to other variables in the filter for an additional level of customization in dashboards
+  2. `from`, `to`, `limit` to control the subset of values to show in the menu in the dashboard (by default, `from=0, to=99` to return the first 100 entries)
 * *Multi-value* variables, or variables with the *Include All* option enabled can **only** be used with `in` and `not ... in` operators.
 * Variables must not be enclosed by quotes.
   > **Note:** The final string will contain quotes when needed (e.g. `$name = $value` will be resolved to `metric = "foo"`).

--- a/src/metrics_service.js
+++ b/src/metrics_service.js
@@ -111,8 +111,11 @@ export default class MetricsService {
                                 to: requestTime.to * 1000000
                             },
                             metrics: [queryOptions.labelName],
-                            filter: null,
-                            paging: { from: 0, to: 99 }
+                            filter: TemplatingService.resolveQueryVariables(
+                                queryOptions.filter,
+                                templateSrv
+                            ),
+                            paging: { from: queryOptions.from, to: queryOptions.to }
                         }
                     });
                 })

--- a/src/templating_service.js
+++ b/src/templating_service.js
@@ -2,49 +2,35 @@ import FormatterService from './formatter_service';
 
 export default class TemplatingService {
     static validateLabelValuesQuery(query) {
-        if (query) {
-            const labelNamePattern = '([A-Za-z][A-Za-z0-9]*(?:[\\._\\-:][a-zA-Z0-9]+)*)';
-            const functionPattern = `label_values\\((?:${labelNamePattern})\\)`;
-            const regex = query.match(`^${functionPattern}$`);
-            if (regex) {
-                return { labelName: regex[1] };
-            } else {
-                return null;
-            }
+        const parsed = parseFunction(query, 'label_values');
+        if (parsed) {
+            return parseOptions(parsed.options, 'label_values');
         } else {
             return null;
         }
     }
 
     static validateLabelNamesQuery(query) {
-        if (query) {
-            const functionPattern = `label_names\\((?:(.*))\\)`;
-            const regex = query.match(`^${functionPattern}$`);
-            if (regex) {
-                const pattern = regex[1];
-                const patternRegex = new RegExp(pattern);
-
-                return { pattern, regex: patternRegex };
-            } else {
-                return null;
-            }
+        const parsed = parseFunction(query, 'label_names');
+        if (parsed) {
+            return { pattern: parsed.options, regex: new RegExp(parsed.options) };
         } else {
             return null;
         }
     }
 
     static validateMetricsQuery(query) {
-        if (query) {
-            const functionPattern = `metrics\\((?:(.*))\\)`;
-            const regex = query.match(`^${functionPattern}$`);
-            if (regex) {
-                const pattern = regex[1];
-                const patternRegex = new RegExp(pattern);
+        const parsed = parseFunction(query, 'metrics');
+        if (parsed) {
+            return { pattern: parsed.options, regex: new RegExp(parsed.options) };
+        } else {
+            return null;
+        }
+    }
 
-                return { pattern, regex: patternRegex };
-            } else {
-                return null;
-            }
+    static resolveQueryVariables(query, templateSrv) {
+        if (query) {
+            return this.replace(templateSrv, query, null);
         } else {
             return null;
         }
@@ -76,6 +62,154 @@ export default class TemplatingService {
             //
             return value.map(format).join(', ');
         }
+    }
+}
+
+function parseFunction(value, functionName) {
+    if (value) {
+        const functionPattern = `${functionName}\\((?:(.*))\\)`;
+        const regex = value.match(`^${functionPattern}$`);
+        if (regex) {
+            const options = regex[1];
+
+            return { options };
+        } else {
+            return null;
+        }
+    } else {
+        return null;
+    }
+}
+
+function parseOptions(value, functionName) {
+    switch (functionName) {
+        case 'label_values': {
+            const parseConfiguration = {
+                namelessOption: {
+                    name: 'labelName',
+                    pattern: '([A-Za-z][A-Za-z0-9]*(?:[\\._\\-:][a-zA-Z0-9]+)*)'
+                },
+                namedOptions: [
+                    {
+                        name: 'filter',
+                        patterns: [`"([^"]+)"`, `'([^']+)'`],
+                        validate: (value) => value.trim(),
+                        defaultValue: null
+                    },
+                    {
+                        name: 'from',
+                        pattern: '(\\d+)',
+                        validate: (value) => Number(value),
+                        defaultValue: 0
+                    },
+                    {
+                        name: 'to',
+                        pattern: '(\\d+)',
+                        validate: (value) => Number(value),
+                        defaultValue: undefined
+                    },
+                    {
+                        name: 'limit',
+                        pattern: '(\\d+)',
+                        validate: (value) => Number(value),
+                        defaultValue: 99
+                    }
+                ],
+                validate: (options) => {
+                    // to overrides limit
+                    if (options.to !== undefined && options.limit !== undefined) {
+                        delete options.limit;
+                    }
+
+                    // to is always derived from from + limit
+                    if (options.limit !== undefined) {
+                        options.to = options.from + options.limit;
+                        delete options.limit;
+                    }
+
+                    // ensure both from+to are always set
+                    if (options.from !== undefined && options.to === undefined) {
+                        options.to = options.from + 99;
+                    } else if (options.to !== undefined && options.from === undefined) {
+                        options.from = options.to - 99;
+                    }
+
+                    // don't let download too much data, but not even too few
+                    if (options.from !== undefined && options.to !== undefined) {
+                        options.from = Math.max(options.from, 0);
+
+                        options.to = Math.min(options.to, options.from + 1000);
+                        options.to = Math.max(options.to, options.from + 1);
+                    }
+
+                    return options;
+                }
+            };
+
+            const functionMatch = value.match(
+                `^${parseConfiguration.namelessOption.pattern}(?:\\s*,\\s*(.+))?$`
+            );
+
+            if (functionMatch) {
+                const parsedOptions = {};
+                parsedOptions[parseConfiguration.namelessOption.name] = functionMatch[1];
+
+                const namedOptions = functionMatch[2];
+                const namedOptionsPattern = parseConfiguration.namedOptions
+                    .reduce((acc, option) => {
+                        if (option.patterns) {
+                            return [
+                                ...acc,
+                                ...option.patterns.map((pattern) => ({
+                                    name: option.name,
+                                    pattern
+                                }))
+                            ];
+                        } else {
+                            return [...acc, option];
+                        }
+                    }, [])
+                    .map((option) => {
+                        return `(?:(${option.name})=${option.pattern})`;
+                    })
+                    .join('|');
+                const namedOptionsRegex = RegExp(namedOptionsPattern, 'g');
+                const namedOptionsValidators = parseConfiguration.namedOptions.reduce((acc, d) => {
+                    acc[d.name] = d.validate;
+                    return acc;
+                }, {});
+
+                let matches;
+                while ((matches = namedOptionsRegex.exec(namedOptions)) !== null) {
+                    for (let i = 1; i < matches.length; i = i + 2) {
+                        if (matches[i]) {
+                            parsedOptions[matches[i]] = namedOptionsValidators[matches[i]](
+                                matches[i + 1]
+                            );
+                        }
+                    }
+                }
+
+                parseConfiguration.namedOptions.forEach((option) => {
+                    if (parsedOptions[option.name] === undefined) {
+                        parsedOptions[option.name] = option.defaultValue;
+                    }
+                });
+
+                const validatedOptions = parseConfiguration.validate(parsedOptions);
+
+                return validatedOptions;
+            } else {
+                return null;
+            }
+        }
+
+        default:
+            console.assert(
+                false,
+                'Options are not supported for any variable function other than "label_values"'
+            );
+            return null;
     }
 }
 


### PR DESCRIPTION
The variable function `label_values` will now accept options.

The syntax is: `label_values(label_name[, filter=string][, from=number][, to=number][, limit=number])`

Here some details:
* `filter` is a string specified with the same syntax of filters available for dashboard panels
* `filter` can use variables that will be used to filter the list of options according to the selection for another variable. The same syntax and restrictions of variables used in panel settings apply
* `from`, `to`, `limit` control how many entries to fetch to populate the variable menu in a dashboard page. By default `from=0, to=99` to fetch the first 100 entries
