### PR TITLE
Support import of text panels from Monitor dashboards

### DIFF
--- a/src/sysdig_dashboard_helper.js
+++ b/src/sysdig_dashboard_helper.js
@@ -99,6 +99,9 @@ export default class SysdigDashboardHelper {
             case 'table':
                 return TableBuilder;
 
+            case 'text':
+                return TextBuilder;
+
             default:
                 console.warn(`${panel.showAs} panels cannot be exported to Grafana`);
                 return DefaultBuilder;
@@ -546,6 +549,27 @@ class TableBuilder extends TimeSeriesBuilder {
                 return metric.aggregation === undefined;
             })
             .map(parseSysdigPanelKey);
+    }
+}
+
+class TextBuilder extends BaseBuilder {
+    static getPanelType() {
+        return 'text';
+    }
+
+    static build(sysdigDashboard, options, sysdigPanel, index) {
+        return Object.assign(
+            {},
+            this.getBasePanelConfiguration(sysdigDashboard, options, sysdigPanel, index),
+            {
+                mode: 'markdown',
+                content: this.getContent(sysdigPanel)
+            }
+        );
+    }
+
+    static getContent(sysdigPanel) {
+        return sysdigPanel.markdownSource;
     }
 }
 


### PR DESCRIPTION
Sysdig Monitor supports text panels (see [Support page](https://sysdigdocs.atlassian.net/wiki/spaces/Monitor/pages/213319798/Configure+Panels#ConfigurePanels-Text)).

Now you can import them to Grafana dashboards.

**Notes**:
* Markdown is supported
* Additional options from Monitor (show panel title, transparent background, auto-size text) are not supported
