### PR TITLE
Import default dashboards

### DIFF
--- a/src/config_ctrl.js
+++ b/src/config_ctrl.js
@@ -28,6 +28,12 @@ export class SysdigConfigCtrl {
         ];
 
         this.dashboardSets = [
+            {
+                id: 'DEFAULT',
+                title: 'Default dashboards',
+                importStatus: 'none',
+                importMessage: null
+            },
             { id: 'PRIVATE', title: 'My dashboards', importStatus: 'none', importMessage: null },
             { id: 'SHARED', title: 'Shared dashboards', importStatus: 'none', importMessage: null }
         ];

--- a/src/config_ctrl.js
+++ b/src/config_ctrl.js
@@ -66,7 +66,7 @@ export class SysdigConfigCtrl {
     }
 
     isDashboardsImportDisabled() {
-        return this.current.id === undefined;
+        return this.current.id === undefined || this.current.jsonData.apiToken === undefined;
     }
 
     importDashboards(dashboardSetId) {

--- a/src/config_ctrl.js
+++ b/src/config_ctrl.js
@@ -95,6 +95,10 @@ export class SysdigConfigCtrl {
                 dashboardSet.importMessage = error;
             });
     }
+
+    deleteDashboards() {
+        DashboardsService.delete(this.backendSrv);
+    }
 }
 
 SysdigConfigCtrl.templateUrl = 'partials/config.html';

--- a/src/dashboards_service.js
+++ b/src/dashboards_service.js
@@ -22,7 +22,7 @@ export default class DashboardsService {
         console.info('Sysdig dashboards import: Starting...');
 
         if (dashboardSetId === 'DEFAULT') {
-            const tags = ['sysdig', 'default dashboard'];
+            const tags = ['Sysdig', 'Default dashboard'];
             return backend.backendSrv.$q
                 .all([
                     ApiService.send(backend, {
@@ -111,10 +111,10 @@ export default class DashboardsService {
             let tags;
             switch (dashboardSetId) {
                 case 'PRIVATE':
-                    tags = ['sysdig', 'private dashboard'];
+                    tags = ['Sysdig', 'Private dashboard'];
                     break;
                 case 'SHARED':
-                    tags = ['sysdig', 'shared dashboard'];
+                    tags = ['Sysdig', 'Shared dashboard'];
                     break;
                 default:
                     throw {
@@ -200,7 +200,7 @@ export default class DashboardsService {
         backendSrv
             .search({
                 type: 'dash-db',
-                tag: 'sysdig'
+                tags: ['Sysdig', 'sysdig']
             })
             .then((dashboards) => {
                 removeDashboards(backendSrv, dashboards);

--- a/src/dashboards_service.js
+++ b/src/dashboards_service.js
@@ -111,7 +111,7 @@ export default class DashboardsService {
             let tags;
             switch (dashboardSetId) {
                 case 'PRIVATE':
-                    tags = ['sysdig', 'my dashboard'];
+                    tags = ['sysdig', 'private dashboard'];
                     break;
                 case 'SHARED':
                     tags = ['sysdig', 'shared dashboard'];

--- a/src/dashboards_service.js
+++ b/src/dashboards_service.js
@@ -195,4 +195,33 @@ export default class DashboardsService {
             }
         }
     }
+
+    static delete(backendSrv) {
+        backendSrv
+            .search({
+                type: 'dash-db',
+                tag: 'sysdig'
+            })
+            .then((dashboards) => {
+                removeDashboards(backendSrv, dashboards);
+            });
+    }
+}
+
+function removeDashboards(backendSrv, dashboards) {
+    if (dashboards.length > 0) {
+        return removeNextDashboard(backendSrv, dashboards[0], dashboards.slice(1));
+    } else {
+        return backendSrv.$q.resolve();
+    }
+}
+
+function removeNextDashboard(backendSrv, dashboard, nextDashboards) {
+    return backendSrv
+        .deleteDashboard(dashboard.uid)
+        .then(() => removeDashboards(backendSrv, nextDashboards))
+        .catch((error) => {
+            console.error('Error deleting dashboard', dashboard.uid, error);
+            removeDashboards(backendSrv, nextDashboards);
+        });
 }

--- a/src/partials/config.html
+++ b/src/partials/config.html
@@ -160,7 +160,7 @@ limitations under the License.
 <!--                   -->
 <!-- Import dashboards -->
 <!--                   -->
-<h3 class="page-heading">Sysdig Monitor Dashboards</h3>
+<h3 class="page-heading">Sysdig Dashboards</h3>
 
 <p class="sysdig-config-editor-info">
   Created some dashboards in Sysdig Monitor already? No worries, you can import them to Grafana!
@@ -185,7 +185,7 @@ limitations under the License.
             <span>{{dashboardSet.title}}</span>
           </td>
           <td>
-            <button class="btn btn-secondary btn-small" ng-disabled="ctrl.isDashboardsImportDisabled()" ng-click="ctrl.importDashboards(dashboardSet.id)">
+            <button class="btn btn-secondary btn-small" ng-disabled="ctrl.isDashboardsImportDisabled()" ng-click="ctrl.importDashboards(dashboardSet.id); $event.stopPropagation();">
               Import
             </button>
             <div style="display: inline-block; margin: 0 10px; min-width: 13px;">
@@ -199,3 +199,7 @@ limitations under the License.
     </table>
   </div>
 </div>
+
+<p class="sysdig-config-editor-info" ng-if="ctrl.isDashboardsImportDisabled() === false">
+  <strong>Note</strong>: Imported dashboards will have the <code>sysdig</code> tag, and this tag will be used to delete all dashboards imported from Sysdig.
+</p>

--- a/src/partials/config.html
+++ b/src/partials/config.html
@@ -195,6 +195,25 @@ limitations under the License.
             </div>
           </td>
         </tr>
+
+        <tr>
+          <td class="width-1 p-t-2">
+            <i class="icon-gf icon-gf-remove"></i>
+          </td>
+          <td class="p-t-2">
+            <span>Delete Sysdig dashboards</span>
+          </td>
+          <td class="p-t-2">
+            <button class="btn btn-danger btn-small" ng-disabled="ctrl.isDashboardsImportDisabled()" ng-click="ctrl.deleteDashboards(); $event.stopPropagation();">
+              Delete
+            </button>
+            <div style="display: inline-block; margin: 0 10px; min-width: 13px;">
+              <i class="fa fa-spinner" ng-show="dashboardSet.importStatus === 'executing'"></i>
+              <i class="fa fa-check" ng-show="dashboardSet.importStatus === 'success'"></i>
+              <i class="fa fa-exclamation-triangle" ng-show="dashboardSet.importStatus === 'error'"></i>
+            </div>
+          </td>
+        </tr>
       </tbody>
     </table>
   </div>


### PR DESCRIPTION
The user can import default dashboards from Monitor, in addition to custom dashboards.

Also, the user can delete all imported dashboards (ie. dashboards with tag `sysdig` added by the datasource during import).

Note that tags will be automatically applied to imported dashboards:
1. Default dashboards: `Sysdig`, `Default dashboard`
2. Private custom dashboards: `Sysdig`, `Private dashboard`
3. Shared custom dashboards: `Sysdig`, `Shared dashboard`

**Datasource editor**

![Screen Shot 2019-03-22 at 1 33 03 PM](https://user-images.githubusercontent.com/5033993/54851508-5de44080-4ca7-11e9-8dd0-0390707e2087.png)


**Dashboards menu**

![Screen Shot 2019-03-22 at 1 34 57 PM](https://user-images.githubusercontent.com/5033993/54851514-60df3100-4ca7-11e9-82bf-318afa5aaaf4.png)
