### PR TITLE
Support multiple segmentations

### DIFF
--- a/src/datasource.js
+++ b/src/datasource.js
@@ -102,16 +102,23 @@ export class SysdigDatasource {
                     isSingleDataPoint: isTabularFormat || targets[0].isSingleDataPoint
                 };
 
+                if (Array.isArray(targetOptions.segmentBy) === false) {
+                    // backwards compatibility: up to v0.3 one segmentation was supported only
+                    targetOptions.segmentBy = [targetOptions.segmentBy];
+                }
+
                 return Object.assign({}, target, targetOptions, {
                     target: TemplatingService.replaceSingleMatch(
                         this.templateSrv,
                         target.target,
                         options.scopedVars
                     ),
-                    segmentBy: TemplatingService.replaceSingleMatch(
-                        this.templateSrv,
-                        targetOptions.segmentBy,
-                        options.scopedVars
+                    segmentBy: targetOptions.segmentBy.map((segmentBy) =>
+                        TemplatingService.replaceSingleMatch(
+                            this.templateSrv,
+                            segmentBy,
+                            options.scopedVars
+                        )
                     ),
                     filter: TemplatingService.replace(
                         this.templateSrv,

--- a/src/partials/query.editor.html
+++ b/src/partials/query.editor.html
@@ -53,17 +53,28 @@ limitations under the License.
   </div>
 
   <!-- Segmentation -->
-  <div class="gf-form gf-form-inline" ng-if="ctrl.panel.type !== 'table' || ctrl.isFirstTarget()">
+  <div class="gf-form gf-form-inline" ng-repeat="item in ctrl.segmentByItems">
     <div class="gf-form gf-form--grow">
-      <label class="gf-form-label width-11">
+      <label class="gf-form-label width-11" ng-if="item.isFirst === true">
         Segment by
       </label>
+      <label class="gf-form-label width-11" ng-if="item.isFirst === false"></label>
+      
       <div class="gf-form gf-form--grow">
-        <gf-form-dropdown model="ctrl.target.segmentBy" class="gf-form-dropdown sysdig-query-editor-dropdown--grow" allow-custom="true"
-          lookup-text="true" placeholder="no segmentation" get-options="ctrl.getSegmentByOptions($query)" on-change="ctrl.onChangeParameter()">
+        <gf-form-dropdown model="item.segmentBy" class="gf-form-dropdown sysdig-query-editor-dropdown--grow" allow-custom="true"
+        lookup-text="true" placeholder="no segmentation" get-options="ctrl.getSegmentByOptions(item, $query)" on-change="ctrl.onChangeParameter()">
         </gf-form-dropdown>
       </div>
-    </div>
+
+      <div style="min-width: 80px;">
+        <button class="btn btn-inverse" ng-click="ctrl.removeSegmentBy(item)">
+          <i class="fa fa-trash" />
+        </button>
+        <button class="btn btn-inverse" ng-click="ctrl.addSegmentBy(item)">
+          <i class="fa fa-plus" />
+        </button>
+      </div>
+     </div>
   </div>
 
   <!-- Filter -->
@@ -79,7 +90,7 @@ limitations under the License.
   </div>
 
   <!-- Time series vs data point -->
-  <div class="gf-form gf-form-inline" ng-if="ctrl.panel.type !== 'table' && ctrl.isFirstTarget()">
+  <div class="gf-form gf-form-inline" ng-if="ctrl.target.isTabularFormat === false && ctrl.isFirstTarget()">
     <div class="gf-form gf-form--grow">
       <div class="gf-form gf-form--grow">
         <gf-form-switch class="gf-form" label="Fetch single data point" label-class="width-11" checked="ctrl.target.isSingleDataPoint"

--- a/src/sysdig_dashboard_helper.js
+++ b/src/sysdig_dashboard_helper.js
@@ -553,7 +553,7 @@ class TableBuilder extends TimeSeriesBuilder {
 
     static buildTargets(sysdigDashboard, sysdigPanel) {
         const keys = this.getKeys(sysdigDashboard, sysdigPanel);
-        const filterMetrics = (metric) => metric.metricId !== keys[0].metricId;
+        const filterMetrics = (metric) => metric.timeAggregation !== undefined;
 
         return sysdigPanel.metrics
             .map(parseSysdigPanelValue)
@@ -566,7 +566,7 @@ class TableBuilder extends TimeSeriesBuilder {
                     target: value.metricId,
                     timeAggregation: value.timeAggregation || 'concat',
                     groupAggregation: value.groupAggregation || 'concat',
-                    segmentBy: keys.length >= 1 ? keys[0].metricId : null,
+                    segmentBy: keys.map((key) => key.metricId),
                     filter: this.getTargetFilter(sysdigDashboard, sysdigPanel),
                     sortDirection: this.getTargetSortDirection(sysdigPanel),
                     pageLimit: this.getTargetPageLimit(sysdigPanel)


### PR DESCRIPTION
Add a way to add more than one segmentation for metrics in dashboard panels.

Before the change, you could select a single segmentation:
<img width="1552" alt="Screen Shot 2019-04-02 at 3 14 14 PM" src="https://user-images.githubusercontent.com/5033993/55439611-058c2900-555a-11e9-835f-b4c705754550.png">

Now you can add more than one:
<img width="1552" alt="Screen Shot 2019-04-02 at 3 13 48 PM" src="https://user-images.githubusercontent.com/5033993/55439615-08871980-555a-11e9-90a9-6dcecb9872d4.png">

Also, this means that tables now supports multiple key columns as well:
<img width="1552" alt="Screen Shot 2019-04-02 at 3 16 05 PM" src="https://user-images.githubusercontent.com/5033993/55439690-42582000-555a-11e9-9c17-75c3ccee0650.png">
