### PR TITLE
Improve metrics suggestion menus and aggregations

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,7 @@
 {
     "extends": "eslint:recommended",
     "parserOptions": {
-        "ecmaVersion": 6,
+        "ecmaVersion": 8,
         "sourceType": "module"
     },
     "globals": {

--- a/spec/cache_spec.js
+++ b/spec/cache_spec.js
@@ -1,0 +1,97 @@
+import Cache from '../cache';
+import Q from 'q';
+
+describe('Cache', () => {
+    it('should store items', async () => {
+        const cache = new Cache(Q);
+
+        await cache.get('test-1', () => 'res-1');
+        const res1 = await cache.get('test-1');
+        expect(res1).to.be.equal('res-1');
+
+        await cache.get('test-2', () => 'res-2');
+        const res2 = await cache.get('test-2');
+        expect(res2).to.be.equal('res-2');
+    });
+
+    it('should store up to MAX items', async () => {
+        const cache = new Cache(Q, 2);
+
+        await cache.get('test-1', () => 'res-1');
+        await cache.get('test-2', () => 'res-2');
+        await cache.get('test-3', () => 'res-3');
+        await cache.get('test-4', () => 'res-4');
+
+        const array = cache.toArray();
+        expect(array).to.have.length(2);
+        expect(array[0]).to.be.equal('res-3');
+        expect(array[1]).to.be.equal('res-4');
+    });
+
+    it('should store up to MAX recently read items', async () => {
+        const cache = new Cache(Q, 2);
+
+        await cache.get('test-1', () => 'res-1');
+        await cache.get('test-2', () => 'res-2');
+        await cache.get('test-1');
+        await cache.get('test-4', () => 'res-4');
+
+        const array = cache.toArray();
+        expect(array).to.have.length(2);
+        expect(array[0]).to.be.equal('res-1');
+        expect(array[1]).to.be.equal('res-4');
+    });
+
+    it('should evict expired items', async () => {
+        const cache = new Cache(Q, 10, 10);
+
+        cache.now = () => 0;
+        await cache.get('test-1', () => 'res-1');
+
+        cache.now = () => 10;
+        await cache.get('test-2', () => 'res-2');
+
+        cache.now = () => 20;
+        await cache.get('test-3', () => 'res-3');
+
+        const array = cache.toArray();
+        expect(array).to.have.length(2);
+        expect(array[0]).to.be.equal('res-2');
+        expect(array[1]).to.be.equal('res-3');
+    });
+
+    it('should evict expired items', async () => {
+        const cache = new Cache(Q, 10, 10);
+
+        cache.now = () => 0;
+        await cache.get('test-1', () => 'res-1');
+
+        cache.now = () => 10;
+        await cache.get('test-2', () => 'res-2');
+
+        cache.now = () => 20;
+        await cache.get('test-3', () => 'res-3');
+
+        const array = cache.toArray();
+        expect(array).to.have.length(2);
+        expect(array[0]).to.be.equal('res-2');
+        expect(array[1]).to.be.equal('res-3');
+    });
+
+    it('should evict expired items based on creation time', async () => {
+        const cache = new Cache(Q, 10, 10);
+
+        cache.now = () => 0;
+        await cache.get('test-1', () => 'res-1');
+
+        cache.now = () => 10;
+        await cache.get('test-1');
+
+        cache.now = () => 20;
+        await cache.get('test-3', () => 'res-3');
+
+        const array = cache.toArray();
+        expect(array).to.have.length(1);
+        expect(array[0]).to.be.equal('res-3');
+    });
+});

--- a/spec/datasource_spec.js
+++ b/spec/datasource_spec.js
@@ -1,20 +1,18 @@
-import { Datasource } from '../module';
+import { SysdigDatasource } from '../datasource';
 import Q from 'q';
 
-describe('SysdigDatasource', function() {
+describe('SysdigDatasource', () => {
     var ctx = {};
 
-    beforeEach(function() {
+    beforeEach(() => {
         ctx.$q = Q;
         ctx.backendSrv = {};
         ctx.templateSrv = {};
-        ctx.ds = new Datasource({}, ctx.$q, ctx.backendSrv, ctx.templateSrv);
+        ctx.ds = new SysdigDatasource({}, ctx.$q, ctx.backendSrv, ctx.templateSrv);
     });
 
-    it('should return an empty array when no targets are set', function(done) {
-        ctx.ds.query({ targets: [] }).then(function(result) {
-            expect(result.data).to.have.length(0);
-            done();
-        });
+    it('should return an empty array when no targets are set', async () => {
+        const result = await ctx.ds.query({ targets: [] });
+        expect(result.data).to.have.length(0);
     });
 });

--- a/spec/metrics_service_spec.js
+++ b/spec/metrics_service_spec.js
@@ -1,0 +1,100 @@
+import MetricsService from '../metrics_service';
+import q from 'q';
+
+describe('MetricsService', () => {
+    let backendMock;
+    let backendRequestArgs;
+    let backendResponseStubs;
+
+    beforeEach(() => {
+        MetricsService.reset();
+
+        backendRequestArgs = [];
+        backendResponseStubs = [];
+
+        backendMock = {
+            url: 'dummy://localhost',
+            apiToken: '42',
+            backendSrv: {
+                $q: q,
+                datasourceRequest(options) {
+                    backendRequestArgs.push(options);
+
+                    return q.resolve(backendResponseStubs[backendRequestArgs.length - 1]);
+                }
+            }
+        };
+    });
+
+    it('should set proper default GET parameters', async () => {
+        backendResponseStubs = [
+            {
+                data: {
+                    metricDescriptors: []
+                }
+            }
+        ];
+
+        const metrics = await MetricsService.findMetrics(backendMock, {});
+        expect(metrics).to.be.an('array');
+        expect(metrics).to.have.length(0);
+
+        expect(backendRequestArgs).to.have.length(1);
+        expect(backendRequestArgs[0].url).to.match(/filter=&/);
+    });
+
+    it('should not make the same request twice', async () => {
+        backendResponseStubs = [
+            {
+                data: {
+                    metricDescriptors: []
+                }
+            }
+        ];
+
+        await MetricsService.findMetrics(backendMock, {});
+        await MetricsService.findMetrics(backendMock, {});
+
+        expect(backendRequestArgs).to.have.length(1);
+    });
+
+    it('should set filter when match is specified', async () => {
+        backendResponseStubs = [
+            {
+                data: {
+                    metricDescriptors: []
+                }
+            }
+        ];
+
+        await MetricsService.findMetrics(backendMock, { match: 'test' });
+
+        expect(backendRequestArgs[0].url).to.match(/filter=test&/);
+    });
+
+    it('should use separate caches for different backends', async () => {
+        backendResponseStubs = [
+            {
+                data: {
+                    metricDescriptors: []
+                }
+            },
+            {
+                data: {
+                    metricDescriptors: []
+                }
+            }
+        ];
+
+        await q.all([
+            MetricsService.findMetrics(backendMock, { match: 'test' }),
+            MetricsService.findMetrics(
+                Object.assign({}, backendMock, { url: 'dummy://localhost-2' }),
+                { match: 'test' }
+            )
+        ]);
+
+        expect(backendRequestArgs).to.have.length(2);
+        expect(backendRequestArgs[0].url).not.to.be.equal(backendRequestArgs[1].url);
+    });
+});

--- a/src/cache.js
+++ b/src/cache.js
@@ -1,0 +1,153 @@
+//
+//  Copyright 2018 Draios Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+export default class Cache {
+    constructor($q, maxCount = 10, expiration = Number.MAX_VALUE) {
+        this.$q = $q;
+        this.map = {};
+        this.list = [];
+
+        this.maxCount = maxCount;
+        this.expiration = expiration;
+    }
+
+    getItemId(id) {
+        return id;
+    }
+
+    async get(id, loader) {
+        const data = this.read(id);
+        if (data !== undefined) {
+            return this.$q.resolve(data);
+        } else {
+            const promise = this.fetch(loader);
+
+            // store promise as data first...
+            this.write(id, promise);
+
+            try {
+                // wait for data...
+                const data = await promise;
+
+                // and finally store data in the cache
+                this.write(id, data);
+
+                return data;
+            } catch (ex) {
+                // delete pending item
+                const itemId = this.getItemId(id);
+                const item = this.map[itemId];
+                if (item !== undefined) {
+                    this.list = [...this.list.filter((d) => d !== item)];
+                    delete this.map[itemId];
+                }
+
+                throw ex;
+            }
+        }
+    }
+
+    read(id) {
+        const itemId = this.getItemId(id);
+
+        this.expireItems();
+        const item = this.map[itemId];
+
+        if (item) {
+            item.lastAccess = this.now();
+
+            // keep list sorted by creation time
+            this.list = [...this.list.filter((d) => d !== item), item];
+
+            return item.data;
+        } else {
+            return undefined;
+        }
+    }
+
+    fetch(loader) {
+        return this.$q.resolve(loader());
+    }
+
+    write(id, data) {
+        const itemId = this.getItemId(id);
+
+        const item = this.createItem(itemId, data);
+
+        // replace existing items (used to replace promise with data)
+        const previousItem = this.map[itemId];
+        if (previousItem !== undefined) {
+            this.list = [...this.list.filter((d) => d !== previousItem)];
+            delete this.map[itemId];
+        }
+
+        this.list.push(item);
+        this.map[itemId] = item;
+
+        this.evictItems();
+
+        return item.data;
+    }
+
+    createItem(itemId, data) {
+        const now = this.now();
+
+        return {
+            id: itemId,
+            data,
+            createdOn: now,
+            lastAccess: now
+        };
+    }
+
+    expireItems() {
+        if (this.expiration !== Number.MAX_VALUE) {
+            const limit = this.now() - this.expiration;
+            const removed = [];
+            for (let i = this.list.length - 1; i >= 0; i--) {
+                const item = this.list[i];
+
+                if (item.createdOn < limit) {
+                    delete this.map[item.id];
+                    removed.push(i);
+                }
+            }
+
+            this.list = this.list.filter((d, i) => removed.indexOf(i) === -1);
+        }
+    }
+
+    evictItems() {
+        if (this.list.length > this.maxCount) {
+            const removed = [];
+            for (let i = this.list.length - 1 - this.maxCount; i >= 0; i--) {
+                const item = this.list[i];
+
+                delete this.map[item.id];
+                removed.push(i);
+            }
+
+            this.list = this.list.filter((d, i) => removed.indexOf(i) === -1);
+        }
+    }
+
+    toArray() {
+        return this.list.map((item) => item.data);
+    }
+
+    now() {
+        return Date.now();
+    }
+}

--- a/src/datasource.js
+++ b/src/datasource.js
@@ -140,11 +140,14 @@ export class SysdigDatasource {
 
     metricFindQuery(query, options) {
         const normOptions = Object.assign(
-            { areLabelsIncluded: false, range: null, variable: null },
+            { areLabelsIncluded: false, range: null, variable: null, match: '' },
             options
         );
 
         if (query) {
+            //
+            // variable query
+            //
             return MetricsService.queryMetrics(
                 this.getBackendConfiguration(),
                 this.templateSrv,
@@ -158,8 +161,14 @@ export class SysdigDatasource {
                     }))
             );
         } else {
+            //
+            // panel configuration query
+            //
             return (
-                MetricsService.findMetrics(this.getBackendConfiguration())
+                MetricsService.findMetrics(this.getBackendConfiguration(), {
+                    areLabelsIncluded: normOptions.areLabelsIncluded,
+                    match: normOptions.match
+                })
                     // filter out all tags/labels/other string metrics
                     .then((result) => {
                         if (normOptions.areLabelsIncluded) {
@@ -172,14 +181,14 @@ export class SysdigDatasource {
         }
     }
 
-    findSegmentBy(target) {
-        if (target === undefined || target === 'select metric') {
-            return MetricsService.findSegmentations(this.getBackendConfiguration(), null);
+    findSegmentBy(metric, query) {
+        if (metric) {
+            return MetricsService.findSegmentations(this.getBackendConfiguration(), {
+                metric,
+                match: TemplatingService.replaceSingleMatch(this.templateSrv, query)
+            });
         } else {
-            return MetricsService.findSegmentations(
-                this.getBackendConfiguration(),
-                TemplatingService.replaceSingleMatch(this.templateSrv, target)
-            );
+            return this.getBackendConfiguration().backendSrv.$q.when([]);
         }
     }
 

--- a/src/metrics_service.js
+++ b/src/metrics_service.js
@@ -20,7 +20,7 @@ import TemplatingService from './templating_service';
 import Cache from './cache';
 
 export default class MetricsService {
-    static async findMetrics(backend, options) {
+    static findMetrics(backend, options) {
         const normOptions = Object.assign({ areLabelsIncluded: false, match: null }, options);
 
         if (normOptions.match && normOptions.match.trim() === '') {

--- a/src/partials/query.editor.html
+++ b/src/partials/query.editor.html
@@ -62,7 +62,7 @@ limitations under the License.
       
       <div class="gf-form gf-form--grow">
         <gf-form-dropdown model="item.segmentBy" class="gf-form-dropdown sysdig-query-editor-dropdown--grow" allow-custom="true"
-        lookup-text="true" placeholder="no segmentation" get-options="ctrl.getSegmentByOptions(item, $query)" on-change="ctrl.onChangeParameter()">
+        lookup-text="true" get-options="ctrl.getSegmentByOptions(item, $query)" on-change="ctrl.onChangeParameter()">
         </gf-form-dropdown>
       </div>
 

--- a/src/query_ctrl.js
+++ b/src/query_ctrl.js
@@ -46,6 +46,13 @@ export class SysdigDatasourceQueryCtrl extends QueryCtrl {
         return this.panel.targets.indexOf(this.target) === 0;
     }
 
+    getVariableItems() {
+        return this.datasource.templateSrv.variables.map((variable) => {
+            const text = `\${${variable.name}}`;
+            return { text, value: text };
+        });
+    }
+
     getMetricOptions(query) {
         let parseMetric;
         let options = {
@@ -66,7 +73,7 @@ export class SysdigDatasourceQueryCtrl extends QueryCtrl {
         }
 
         return this.datasource.metricFindQuery(null, options).then((data) => {
-            return data.map(parseMetric);
+            return [...this.getVariableItems(), ...data.map(parseMetric)];
         });
     }
 
@@ -130,6 +137,7 @@ export class SysdigDatasourceQueryCtrl extends QueryCtrl {
             .then((data) => {
                 return [
                     { text: 'no segmentation', value: null },
+                    ...this.getVariableItems(),
                     ...data.map((m) => ({ text: m.id, value: m.id }))
                 ];
             });

--- a/src/query_ctrl.js
+++ b/src/query_ctrl.js
@@ -16,6 +16,35 @@
 import { QueryCtrl } from 'app/plugins/sdk';
 import './css/query-editor.css!';
 
+const DEFAULT_TIME_AGGREGATIONS = [
+    { value: 'avg', text: 'Average' },
+    { value: 'timeAvg', text: 'Rate' },
+    { value: 'sum', text: 'Sum' },
+    { value: 'min', text: 'Min' },
+    { value: 'max', text: 'Max' },
+    { value: 'count', text: 'Count' },
+    { value: 'concat', text: 'Concat' },
+    { value: 'distinct', text: 'Distinct' }
+];
+const DEFAULT_TIME_AGGREGATIONS_MAP = DEFAULT_TIME_AGGREGATIONS.reduce((acc, d) => {
+    acc[d.value] = d;
+    return acc;
+}, {});
+
+const DEFAULT_GROUP_AGGREGATIONS = [
+    { value: 'avg', text: 'Average' },
+    { value: 'sum', text: 'Sum' },
+    { value: 'min', text: 'Min' },
+    { value: 'max', text: 'Max' },
+    { value: 'count', text: 'Count' },
+    { value: 'concat', text: 'Concat' },
+    { value: 'distinct', text: 'Distinct' }
+];
+const DEFAULT_GROUP_AGGREGATIONS_MAP = DEFAULT_GROUP_AGGREGATIONS.reduce((acc, d) => {
+    acc[d.value] = d;
+    return acc;
+}, {});
+
 export class SysdigDatasourceQueryCtrl extends QueryCtrl {
     constructor($scope, $injector) {
         super($scope, $injector);
@@ -84,20 +113,13 @@ export class SysdigDatasourceQueryCtrl extends QueryCtrl {
     }
 
     getTimeAggregationOptions() {
-        const options = [
-            { value: 'avg', text: 'Average' },
-            { value: 'timeAvg', text: 'Rate' },
-            { value: 'sum', text: 'Sum' },
-            { value: 'min', text: 'Min' },
-            { value: 'max', text: 'Max' },
-            { value: 'count', text: 'Count' },
-            { value: 'concat', text: 'Concat' },
-            { value: 'distinct', text: 'Distinct' }
-        ];
-
         return this.getAggregationOptions().then((m) => {
             if (m) {
-                return options.filter((d) => m.timeAggregations.indexOf(d.value) >= 0);
+                return getAggregationList(
+                    m.timeAggregations,
+                    DEFAULT_TIME_AGGREGATIONS,
+                    DEFAULT_TIME_AGGREGATIONS_MAP
+                );
             } else {
                 return [];
             }
@@ -105,19 +127,13 @@ export class SysdigDatasourceQueryCtrl extends QueryCtrl {
     }
 
     getGroupAggregationOptions() {
-        const options = [
-            { value: 'avg', text: 'Average' },
-            { value: 'sum', text: 'Sum' },
-            { value: 'min', text: 'Min' },
-            { value: 'max', text: 'Max' },
-            { value: 'count', text: 'Count' },
-            { value: 'concat', text: 'Concat' },
-            { value: 'distinct', text: 'Distinct' }
-        ];
-
         return this.getAggregationOptions().then((m) => {
             if (m) {
-                return options.filter((d) => m.groupAggregations.indexOf(d.value) >= 0);
+                return getAggregationList(
+                    m.groupAggregations,
+                    DEFAULT_GROUP_AGGREGATIONS,
+                    DEFAULT_GROUP_AGGREGATIONS_MAP
+                );
             } else {
                 return [];
             }
@@ -214,3 +230,22 @@ export class SysdigDatasourceQueryCtrl extends QueryCtrl {
 }
 
 SysdigDatasourceQueryCtrl.templateUrl = 'partials/query.editor.html';
+
+function getAggregationList(aggregations, knownList, knownMap) {
+    return aggregations
+        .map((d) => {
+            const descr = knownMap[d];
+
+            return descr || { text: d, value: d };
+        })
+        .sort((a, b) => {
+            const indexA = knownList.indexOf(a);
+            const indexB = knownList.indexOf(b);
+
+            if (indexA !== indexB) {
+                return indexA - indexB;
+            } else {
+                return a.text.localeCompare(b.text);
+            }
+        });
+}


### PR DESCRIPTION
![Screen Shot 2019-04-30 at 2 31 47 PM](https://user-images.githubusercontent.com/5033993/56994708-c2bb7200-6b54-11e9-867c-ecce8be0f834.png)

The list of metrics and segmentations are fetched via API. The datasource was still using an older endpoint to retrieve available options that were not providing the entire list of options and didn't support a filtering mechanism.

Also, all aggregations reported by API will be exposed in the query UI.

Finally, a better caching mechanism is now implemented to prevent the same API requests to be made.