### PR TITLE
Support "Rate of change" aggregation, and rename "rate"

### DIFF
--- a/src/query_ctrl.js
+++ b/src/query_ctrl.js
@@ -18,8 +18,9 @@ import './css/query-editor.css!';
 import { DEFAULT_PAGE_LIMIT } from './datasource';
 
 const DEFAULT_TIME_AGGREGATIONS = [
+    { value: 'timeAvg', text: 'Time average' },
+    { value: 'rateOfChange', text: 'Rate of change' },
     { value: 'avg', text: 'Average' },
-    { value: 'timeAvg', text: 'Rate' },
     { value: 'sum', text: 'Sum' },
     { value: 'min', text: 'Min' },
     { value: 'max', text: 'Max' },
@@ -145,7 +146,10 @@ export class SysdigDatasourceQueryCtrl extends QueryCtrl {
     }
 
     getSortDirectionOptions() {
-        return [{ value: 'desc', text: 'Top' }, { value: 'asc', text: 'Bottom' }];
+        return [
+            { value: 'desc', text: 'Top' },
+            { value: 'asc', text: 'Bottom' }
+        ];
     }
 
     getSegmentByOptions(item, query) {


### PR DESCRIPTION
When available via API, make _Rate of change_ available as time aggregation.

Also, rename _Rate_ time aggregation to _Time average_ to make it less ambiguous.

<img width="1552" alt="Screen Shot 2020-02-11 at 2 18 07 PM" src="https://user-images.githubusercontent.com/5033993/74284793-6091bf00-4cd9-11ea-8f88-6910a221bc75.png">
