### PR TITLE
Make "Dashboards delete" action more subtle

### DIFF
--- a/src/partials/config.html
+++ b/src/partials/config.html
@@ -195,30 +195,10 @@ limitations under the License.
             </div>
           </td>
         </tr>
-
-        <tr>
-          <td class="width-1 p-t-2">
-            <i class="icon-gf icon-gf-remove"></i>
-          </td>
-          <td class="p-t-2">
-            <span>Delete Sysdig dashboards</span>
-          </td>
-          <td class="p-t-2">
-            <button class="btn btn-danger btn-small" ng-disabled="ctrl.isDashboardsImportDisabled()" ng-click="ctrl.deleteDashboards(); $event.stopPropagation();">
-              Delete
-            </button>
-            <div style="display: inline-block; margin: 0 10px; min-width: 13px;">
-              <i class="fa fa-spinner" ng-show="dashboardSet.importStatus === 'executing'"></i>
-              <i class="fa fa-check" ng-show="dashboardSet.importStatus === 'success'"></i>
-              <i class="fa fa-exclamation-triangle" ng-show="dashboardSet.importStatus === 'error'"></i>
-            </div>
-          </td>
-        </tr>
       </tbody>
     </table>
   </div>
 </div>
 
 <p class="sysdig-config-editor-info" ng-if="ctrl.isDashboardsImportDisabled() === false">
-  <strong>Note</strong>: Imported dashboards will have the <code>sysdig</code> tag, and this tag will be used to delete all dashboards imported from Sysdig.
-</p>
+  <strong>Note</strong>: Imported dashboards will have the <code>sysdig</code> tag, and this tag will be used to delete all dashboards imported from Sysdig. You can delete all dashboards with <code>sysdig</code> tag by clicking <a style="text-decoration: underline;" ng-click="ctrl.deleteDashboards();">here</a>


### PR DESCRIPTION
Being an uncommon and potentially dangerous action, "dashboards delete" button is now a little more subtle:

<img width="1552" alt="Screen Shot 2020-02-11 at 2 13 07 PM" src="https://user-images.githubusercontent.com/5033993/74284697-24f6f500-4cd9-11ea-8304-96c825539524.png">
