### PR TITLE
Fix data request for historical requests

### DIFF
--- a/src/time_service.js
+++ b/src/time_service.js
@@ -63,9 +63,9 @@ function getRequestTime(timelines, alignments, userTime) {
     const timespan = toUs - fromUs;
 
     //
-    // Use alignments that allow the required timespan
+    // Find aligment to use given timespan ONLY
     //
-    const validAlignments = alignments.filter((a) => {
+    let validAlignments = alignments.filter((a) => {
         return timespan <= a.max * 1000000;
     });
 
@@ -98,6 +98,22 @@ function getRequestTime(timelines, alignments, userTime) {
     }
 
     //
+    // Find minimum sampling (ie. highest resolution) available given the timespan and alignments
+    //
+    const sampling = validTimelines[0].sampling / 1000000;
+
+    //
+    // Find aligments to use given timespan AND sampling
+    //
+    validAlignments = validAlignments.filter((a) => {
+        return a.sampling >= sampling;
+    });
+
+    if (validAlignments.length === 0) {
+        return null;
+    }
+
+    //
     // Align time window with required alignment
     //
     const alignTo = validAlignments[0].alignTo * 1000000;
@@ -116,7 +132,7 @@ function getRequestTime(timelines, alignments, userTime) {
         // use the highest data resolution available to display data
         // this comes from the valid timeline with lowest sampling time
         // (NOTE: timelines.agents is assumed to be sorted by `sampling` property in ascending mode)
-        requestTime.sampling = Math.trunc(validTimelines[0].sampling / 1000000);
+        requestTime.sampling = Math.trunc(sampling);
     }
 
     return requestTime;

--- a/src/time_service.js
+++ b/src/time_service.js
@@ -113,7 +113,10 @@ function getRequestTime(timelines, alignments, userTime) {
     };
 
     if (userTime.sampling) {
-        requestTime.sampling = Math.trunc(minSampling / 1000000);
+        // use the highest data resolution available to display data
+        // this comes from the valid timeline with lowest sampling time
+        // (NOTE: timelines.agents is assumed to be sorted by `sampling` property in ascending mode)
+        requestTime.sampling = Math.trunc(validTimelines[0].sampling / 1000000);
     }
 
     return requestTime;


### PR DESCRIPTION
When selecting an historical time window, the user may select a range that is not available across all timelines (AKA rollups). In these cases, the request should be adjusted to use the lowest sampling available (to allow data to be displayed with the highest resolution).