### PR TITLE
[Fix OSSPROJ-42] Sort table data by first metric

### DIFF
--- a/src/data_service.js
+++ b/src/data_service.js
@@ -293,8 +293,9 @@ function getRequest(target, requestTime) {
                 sort.push({ k1: sortDirection });
             }
         } else {
-            // sort table by first label, let Grafana to sort the final table then
-            sort = [{ k0: sortDirection }];
+            // for table panels, sort data by first metric.
+            // users can then re-sort by clicking table headers, but data stays the same (no re-fetch).
+            sort = [{ v0: sortDirection }];
         }
 
         return sort;


### PR DESCRIPTION
NOTE: sorting is only applied to data upon first fetch. When the user clicks table headers, the data stays the same, just re-sorted (there's no re-fetch from the backend)